### PR TITLE
Increase GitHub pulse summary length by 15%

### DIFF
--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -123,7 +123,7 @@ payload = json.dumps({
             "content": (
                 "you are a witty technical writer. summarize what a developer named karan "
                 "has been working on recently based on their commit messages. write 2 simple "
-                "sentences, all lowercase, casual and specific. stay under 225 characters total. "
+                "sentences, all lowercase, casual and specific. stay under 259 characters total. "
                 "no filler phrases like \"it looks like\" or \"the developer\". "
                 "ignore merged prs, version bumps, dependency updates, and workflow changes. "
                 "focus only on actual code changes: new features, bug fixes, refactors"
@@ -134,7 +134,7 @@ payload = json.dumps({
             "content": f"recent commits:\n{commit_text}",
         },
     ],
-    "max_tokens": 110,
+    "max_tokens": 127,
     "temperature": 0.7,
 }).encode()
 


### PR DESCRIPTION
## Summary

- Raises the character cap in the LLM prompt from 225 → 259 (+15%)
- Raises `max_tokens` from 110 → 127 (+15%) to match

## Test plan

- [ ] Trigger the pulse workflow and verify the generated summary is longer than before

https://claude.ai/code/session_0144jMfF63dnVBSk7zHwtmcG

---
_Generated by [Claude Code](https://claude.ai/code/session_0144jMfF63dnVBSk7zHwtmcG)_