### PR TITLE
replace openresto with sportsbook-meow on homepage and experience

### DIFF
--- a/karan-resume/src/components/ExperienceContent.tsx
+++ b/karan-resume/src/components/ExperienceContent.tsx
@@ -41,13 +41,12 @@ const projects = [
   },
   {
     owner: 'karanshukla',
-    repo: 'karanshukla.ca',
-    title: 'karanshukla.ca',
-    subtitle: 'this website',
+    repo: 'sportsbook-meow',
+    title: 'sportsbook-meow',
+    subtitle: 'real-time sportsbook ad replacement with cats',
     description:
-      'personal portfolio and resume site built with react, typescript, and vite. deployed automatically to github pages via github actions on every push to main. features dark/light mode, responsive layout, and live github repo stats pulled from the public github api.',
-    techStack: ['TypeScript', 'React', 'Vite', 'MUI', 'GitHub Actions'],
-    liveUrl: 'https://karanshukla.ca',
+      'detects and replaces sportsbook betting logos in sports broadcast video — local files and live streams — with random cat photos in real time. uses a fine-tuned yolov8s model (mAP50 0.94+), a local websocket inference server, and a browser extension for chrome, edge, and firefox.',
+    techStack: ['Python', 'YOLOv8', 'TypeScript', 'WebSocket'],
   },
 ];
 

--- a/karan-resume/src/components/ExperienceContent.tsx
+++ b/karan-resume/src/components/ExperienceContent.tsx
@@ -25,7 +25,7 @@ const projects = [
     title: 'openresto',
     subtitle: 'open source restaurant booking system',
     description:
-      'a self-hosted, cloudless table booking system for restaurants — no fees, no data collection, no vendor lock-in. supports multiple restaurant instances per deployment, customer-facing email confirmations via your own address, and a mobile-friendly booking UI. dockerized for easy self-deployment.',
+      'a self-hosted, cloudless table booking system for restaurants - no fees, no data collection, no vendor lock-in. supports multiple restaurant instances per deployment, customer-facing email confirmations via your own address, and a mobile-friendly booking UI. dockerized for easy self-deployment.',
     techStack: ['TypeScript', 'ASP.NET', 'React Native', 'Docker'],
     liveUrl: 'https://openres.to',
   },
@@ -45,7 +45,7 @@ const projects = [
     title: 'sportsbook-meow',
     subtitle: 'real-time sportsbook ad replacement with cats',
     description:
-      'detects and replaces sportsbook betting logos in sports broadcast video — local files and live streams — with random cat photos in real time. uses a fine-tuned yolov8s model (mAP50 0.94+), a local websocket inference server, and a browser extension for chrome, edge, and firefox.',
+      'detects and replaces sportsbook betting logos in sports broadcast video - local files and live streams - with random cat photos in real time. uses a fine-tuned yolov8s model (mAP50 0.94+), a local websocket inference server, and a browser extension for chrome, edge, and firefox.',
     techStack: ['Python', 'YOLOv8', 'TypeScript', 'WebSocket'],
   },
 ];

--- a/karan-resume/src/components/HomeContent.tsx
+++ b/karan-resume/src/components/HomeContent.tsx
@@ -67,17 +67,17 @@ function HomeContent() {
             <Grid size={{ xs: 12, md: 6 }}>
               <Paper sx={{ p: 3, height: '100%' }}>
                 <Typography variant="h6" gutterBottom>
-                  openresto - table booking system for restaurants
+                  sportsbook-meow
                 </Typography>
                 <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                  foss booking system for restaurants as an alternative to cloud solutions
+                  real-time sportsbook ad replacement with cats
                 </Typography>
                 <Typography variant="body1">
-                  a cloudless table booking system built with asp.net for speed and reliability,
-                  with a react native frontend. dockerized for easy deployment. no cloud, no vendor
-                  lock-in, just a simple solution for restaurants
+                  detects and replaces sportsbook betting logos in sports broadcast video with
+                  random cat photos in real time. uses a fine-tuned yolov8s model, a local
+                  websocket inference server, and a browser extension for chrome, edge, and firefox
                 </Typography>
-                <RepoStats owner="karanshukla" repo="openresto" url="https://github.com/karanshukla/openresto" />
+                <RepoStats owner="karanshukla" repo="sportsbook-meow" url="https://github.com/karanshukla/sportsbook-meow" />
               </Paper>
             </Grid>
           </Grid>

--- a/karan-resume/src/tests/ExperienceContent.test.tsx
+++ b/karan-resume/src/tests/ExperienceContent.test.tsx
@@ -33,7 +33,7 @@ describe('ExperienceContent', () => {
     expect(screen.getByText('navyfragen')).toBeInTheDocument();
     expect(screen.getByText('openresto')).toBeInTheDocument();
     expect(screen.getByText('twtournament')).toBeInTheDocument();
-    expect(screen.getAllByText('karanshukla.ca').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('sportsbook-meow')).toBeInTheDocument();
   });
 
   it('renders live urls for projects', () => {

--- a/karan-resume/src/tests/HomeContent.test.tsx
+++ b/karan-resume/src/tests/HomeContent.test.tsx
@@ -49,7 +49,7 @@ describe('HomeContent', () => {
   it('renders both project card titles', () => {
     render(<HomeContent />);
     expect(screen.getByText('navyfragen')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /openresto/i })).toBeInTheDocument();
+    expect(screen.getByText('sportsbook-meow')).toBeInTheDocument();
   });
 
   it('renders github links after fetch resolves', async () => {


### PR DESCRIPTION
## Summary\n\n- **Homepage**: replaced the openresto project card with sportsbook-meow (description, repo stats widget pointing to `karanshukla/sportsbook-meow`)\n- **Experience page**: replaced the `karanshukla.ca` (this website) project card with sportsbook-meow; openresto and the other projects remain\n\n## Changes\n- `karan-resume/src/components/HomeContent.tsx` — swap openresto card for sportsbook-meow\n- `karan-resume/src/components/ExperienceContent.tsx` — swap karanshukla.ca project entry for sportsbook-meow (Python, YOLOv8, TypeScript, WebSocket tech stack)"

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJiFCVVaxxNaVkXBqaWeEF)_