### PR TITLE
fix last.fm card height and reduce pulse summary length

### DIFF
--- a/karan-resume/src/components/LastFmWidget.tsx
+++ b/karan-resume/src/components/LastFmWidget.tsx
@@ -17,7 +17,7 @@ function LastFmWidget() {
   const track = useLastFm();
 
   return (
-    <Paper sx={{ p: 3, height: '100%' }}>
+    <Paper sx={{ p: 3, width: '100%' }}>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
         <MusicNoteIcon fontSize="small" sx={{ color: 'text.secondary' }} />
         <Typography

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -122,8 +122,8 @@ payload = json.dumps({
             "role": "system",
             "content": (
                 "you are a witty technical writer. summarize what a developer named karan "
-                "has been working on recently based on their commit messages. write 3-4 simple "
-                "sentences, all lowercase, casual and specific. stay under 380 characters total. "
+                "has been working on recently based on their commit messages. write 2-3 simple "
+                "sentences, all lowercase, casual and specific. stay under 300 characters total. "
                 "no filler phrases like \"it looks like\" or \"the developer\". "
                 "ignore merged prs, version bumps, dependency updates, and workflow changes. "
                 "focus only on actual code changes: new features, bug fixes, refactors"
@@ -134,7 +134,7 @@ payload = json.dumps({
             "content": f"recent commits:\n{commit_text}",
         },
     ],
-    "max_tokens": 190,
+    "max_tokens": 150,
     "temperature": 0.7,
 }).encode()
 


### PR DESCRIPTION
## Summary\n\n- `LastFmWidget.tsx` — swap `height: '100%'` for `width: '100%'` so it fills its flex Grid item correctly (same fix applied to GitHubPulse previously)\n- `summarize.py` — reduce target back to 2-3 sentences / ≤300 chars / 150 max_tokens so the summary fits within the 4-line clamp without being truncated"

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJiFCVVaxxNaVkXBqaWeEF)_