### PR TITLE
balance homepage project cards

### DIFF
--- a/karan-resume/src/components/HomeContent.tsx
+++ b/karan-resume/src/components/HomeContent.tsx
@@ -49,32 +49,31 @@ function HomeContent() {
 
           <Grid container spacing={3} sx={{ alignItems: 'stretch' }}>
             <Grid size={{ xs: 12, md: 6 }} sx={{ display: 'flex' }}>
-              <Paper sx={{ p: 3, width: '100%' }}>
+              <Paper sx={{ p: 3, width: '100%', display: 'flex', flexDirection: 'column' }}>
                 <Typography variant="h6" gutterBottom>
                   navyfragen
                 </Typography>
                 <Typography variant="subtitle2" color="text.secondary" gutterBottom>
                   bluesky q&a messaging platform
                 </Typography>
-                <Typography variant="body1">
-                  anonymous q&a platform built on bluesky's at protocol - users receive questions
-                  and post answers directly to their bluesky followers. node.js backend with a
-                  react frontend (mantine ui), protected by a waf. includes a dedicated microservice
-                  for generating shareable answer card images, and cron jobs for feed and
-                  notification processing.
+                <Typography variant="body1" sx={{ flexGrow: 1 }}>
+                  anonymous q&a platform on bluesky's at protocol - users receive questions
+                  and post answers to their followers. node.js/react (mantine ui), waf-protected,
+                  with a microservice for answer card images and crons for feed and notification
+                  processing.
                 </Typography>
                 <RepoStats owner="karanshukla" repo="navyfragen-app" url="https://github.com/karanshukla/navyfragen-app" />
               </Paper>
             </Grid>
             <Grid size={{ xs: 12, md: 6 }} sx={{ display: 'flex' }}>
-              <Paper sx={{ p: 3, width: '100%' }}>
+              <Paper sx={{ p: 3, width: '100%', display: 'flex', flexDirection: 'column' }}>
                 <Typography variant="h6" gutterBottom>
                   sportsbook-meow
                 </Typography>
                 <Typography variant="subtitle2" color="text.secondary" gutterBottom>
                   real-time sportsbook ad replacement with cats
                 </Typography>
-                <Typography variant="body1">
+                <Typography variant="body1" sx={{ flexGrow: 1 }}>
                   detects and replaces sportsbook betting logos in sports broadcast video with
                   random cat photos in real time. uses a fine-tuned yolov8s model, a local
                   websocket inference server, and a browser extension for chrome, edge, and firefox


### PR DESCRIPTION
## Summary\n\n- Shortened navyfragen description to roughly match sportsbook-meow in length (~240 chars vs ~230)\n- Added `display: flex, flexDirection: column` to each card's Paper and `flexGrow: 1` on the description Typography, so `RepoStats` is always pinned to the bottom of the card regardless of description length"

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJiFCVVaxxNaVkXBqaWeEF)_