### PR TITLE
fix: update ExperienceContent test to match current job title

### DIFF
--- a/karan-resume/src/tests/ExperienceContent.test.tsx
+++ b/karan-resume/src/tests/ExperienceContent.test.tsx
@@ -20,7 +20,7 @@ afterEach(() => {
 describe('ExperienceContent', () => {
   it('renders the current role', () => {
     render(<ExperienceContent />);
-    expect(screen.getByText(/full stack software engineer/i)).toBeInTheDocument();
+    expect(screen.getByText(/software developer \/ technical support engineer/i)).toBeInTheDocument();
   });
 
   it('renders the education section', () => {


### PR DESCRIPTION
## Summary

- Updated `ExperienceContent.test.tsx` to match the current job title in the component

## Root cause

The role title in `ExperienceContent.tsx` was updated to `"software developer / technical support engineer"` in a recent commit, but the test still asserted on the old text `"full stack software engineer"`, causing the PR Check CI workflow to fail.

## Test plan
- [x] `yarn test:run` passes (86 passed, 3 skipped, 0 failed)

---
_Generated by [Claude Code](https://claude.ai/code/session_013JdP2ow7MKFJdgcLU15rB4)_