### PR TITLE
Add /musings section

### DIFF
--- a/karan-resume/src/components/DynamicChip.tsx
+++ b/karan-resume/src/components/DynamicChip.tsx
@@ -7,6 +7,7 @@ const routeLabels: Record<string, string> = {
   '/experience': 'experience',
   '/hobbies': 'hobbies',
   '/asher-zone': 'asher zone',
+  '/musings': 'musings',
 };
 
 const DynamicChip: React.FC = () => {

--- a/karan-resume/src/components/ListItems.tsx
+++ b/karan-resume/src/components/ListItems.tsx
@@ -8,6 +8,7 @@ import HomeIcon from '@mui/icons-material/Home';
 import PetsIcon from '@mui/icons-material/Pets';
 import WorkHistoryIcon from '@mui/icons-material/WorkHistory';
 import SportsRugbyIcon from '@mui/icons-material/SportsRugby';
+import EditNoteIcon from '@mui/icons-material/EditNote';
 import CodeIcon from '@mui/icons-material/Code';
 import EmailIcon from '@mui/icons-material/Email';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
@@ -81,6 +82,14 @@ export const MainListItems: React.FC = () => {
         </ListItemIcon>
         <ListItemText primary="hobbies" />
         <KeyHint>3</KeyHint>
+      </ListItemButton>
+
+      <ListItemButton component={NavLink} to="/musings" aria-label="musings, press 5">
+        <ListItemIcon aria-hidden="true">
+          <EditNoteIcon />
+        </ListItemIcon>
+        <ListItemText primary="musings" />
+        <KeyHint>5</KeyHint>
       </ListItemButton>
 
       <ListItemButton

--- a/karan-resume/src/components/MusingsContent.tsx
+++ b/karan-resume/src/components/MusingsContent.tsx
@@ -1,0 +1,31 @@
+import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import Slide from '@mui/material/Slide';
+import { usePageTitle } from '../hooks/CommonHooks';
+import musings from '../data/musings';
+
+function MusingsContent() {
+  usePageTitle('musings');
+  return (
+    <Grid container spacing={3}>
+      {musings.map((musing) => (
+        <Grid key={musing.id} size={12}>
+          <Slide direction="up" in={true} mountOnEnter unmountOnExit>
+            <Paper sx={{ p: 3 }}>
+              <Typography component="h2" variant="h6" gutterBottom>
+                {musing.title}
+              </Typography>
+              <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 1.5 }}>
+                {musing.date}
+              </Typography>
+              <Typography variant="body2">{musing.body}</Typography>
+            </Paper>
+          </Slide>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}
+
+export default MusingsContent;

--- a/karan-resume/src/data/musings.ts
+++ b/karan-resume/src/data/musings.ts
@@ -7,10 +7,40 @@ export interface Musing {
 
 const musings: Musing[] = [
   {
-    id: 'immutable-handoff',
-    title: 'Immutable Handoff',
-    date: '2026-06-04',
-    body: 'PLACEHOLDER — copy to be updated.',
+    id: 'emotional-detachment',
+    title: 'Emotional Detachment',
+    date: '2026-06-05',
+    body: 'there has to be a way to use AI effectively without being emotionally attached. why is everyone obsessed with opus 4.8?',
+  },
+  {
+    id: 'build-yourself',
+    title: 'Build Yourself',
+    date: '2026-06-05',
+    body: 'surely there has to be a way to build with AI without forgetting how to build yourself.',
+  },
+  {
+    id: 'excited-about-your-product',
+    title: 'Excited About Your Product',
+    date: '2026-06-05',
+    body: 'using your own product may not be enough. you have to be excited about your own product',
+  },
+  {
+    id: 'agentic-engineering',
+    title: 'Agentic Engineering',
+    date: '2026-06-05',
+    body: 'the tech industry wants "agentic engineering" but doesn\'t really know how to get there',
+  },
+  {
+    id: 'settings-ux',
+    title: 'Settings UX',
+    date: '2026-06-05',
+    body: 'can we please stop nesting app level settings with account settings? its bad enough that its hidden behind a burger menu',
+  },
+  {
+    id: 'the-couch',
+    title: 'The Couch',
+    date: '2026-06-05',
+    body: 'i bought a new couch recently, the cat thinks its hers. despite being afraid of it at first. not sure what thats about',
   },
 ];
 

--- a/karan-resume/src/data/musings.ts
+++ b/karan-resume/src/data/musings.ts
@@ -1,0 +1,17 @@
+export interface Musing {
+  id: string;
+  title: string;
+  date: string;
+  body: string;
+}
+
+const musings: Musing[] = [
+  {
+    id: 'immutable-handoff',
+    title: 'Immutable Handoff',
+    date: '2026-06-04',
+    body: 'PLACEHOLDER — copy to be updated.',
+  },
+];
+
+export default musings;

--- a/karan-resume/src/data/musings.ts
+++ b/karan-resume/src/data/musings.ts
@@ -8,37 +8,37 @@ export interface Musing {
 const musings: Musing[] = [
   {
     id: 'emotional-detachment',
-    title: 'Emotional Detachment',
+    title: 'emotional detachment',
     date: '2026-06-05',
     body: 'there has to be a way to use AI effectively without being emotionally attached. why is everyone obsessed with opus 4.8?',
   },
   {
     id: 'build-yourself',
-    title: 'Build Yourself',
+    title: 'build yourself',
     date: '2026-06-05',
     body: 'surely there has to be a way to build with AI without forgetting how to build yourself.',
   },
   {
     id: 'excited-about-your-product',
-    title: 'Excited About Your Product',
+    title: 'excited about your product',
     date: '2026-06-05',
     body: 'using your own product may not be enough. you have to be excited about your own product',
   },
   {
     id: 'agentic-engineering',
-    title: 'Agentic Engineering',
+    title: 'agentic engineering',
     date: '2026-06-05',
     body: 'the tech industry wants "agentic engineering" but doesn\'t really know how to get there',
   },
   {
     id: 'settings-ux',
-    title: 'Settings UX',
+    title: 'settings ux',
     date: '2026-06-05',
     body: 'can we please stop nesting app level settings with account settings? its bad enough that its hidden behind a burger menu',
   },
   {
     id: 'the-couch',
-    title: 'The Couch',
+    title: 'the couch',
     date: '2026-06-05',
     body: 'i bought a new couch recently, the cat thinks its hers. despite being afraid of it at first. not sure what thats about',
   },

--- a/karan-resume/src/hooks/CommonHooks.tsx
+++ b/karan-resume/src/hooks/CommonHooks.tsx
@@ -34,6 +34,7 @@ export const navShortcuts: Record<string, string> = {
   '2': '/experience',
   '3': '/hobbies',
   '4': '/asher-zone',
+  '5': '/musings',
 };
 
 export const useKeyboardShortcuts = (): void => {

--- a/karan-resume/src/main.tsx
+++ b/karan-resume/src/main.tsx
@@ -10,6 +10,7 @@ import HomeContent from './components/HomeContent.tsx';
 import ExperienceContent from './components/ExperienceContent.tsx';
 import HobbyContent from './components/HobbyContent.tsx';
 import AsherZoneContent from './components/AsherZoneContent.tsx';
+import MusingsContent from './components/MusingsContent.tsx';
 
 const router = createHashRouter([
   {
@@ -20,6 +21,7 @@ const router = createHashRouter([
       { path: 'experience', element: <ExperienceContent /> },
       { path: 'hobbies', element: <HobbyContent /> },
       { path: 'asher-zone', element: <AsherZoneContent /> },
+      { path: 'musings', element: <MusingsContent /> },
     ],
   },
 ]);


### PR DESCRIPTION
## Summary
- Adds `src/data/musings.ts` with a static `Musing[]` array and one placeholder entry ("Immutable Handoff", 2026-06-04)
- Adds `src/components/MusingsContent.tsx` — renders entries as `Paper` cards matching the existing `p: 3` / `Slide` / `Typography` rhythm
- Wires `/musings` route in `main.tsx` alongside existing routes
- Adds "musings" nav item (key `5`) to `ListItems.tsx`, keyboard shortcut to `CommonHooks.tsx`, and label to `DynamicChip.tsx`

No new dependencies, no new design tokens, no markdown renderer.

## Test plan
- [ ] `yarn dev` → navigate to `/musings`, confirm placeholder entry renders
- [ ] Press `5` keyboard shortcut, confirm navigation works
- [ ] Verify drawer nav item "musings" highlights correctly on active route
- [ ] `yarn build` passes with no type errors

https://claude.ai/code/session_0161kvMLs99s77ofepmBqsn1

---
_Generated by [Claude Code](https://claude.ai/code/session_0161kvMLs99s77ofepmBqsn1)_