### PR TITLE
Add haptic feedback to nav and menu buttons

### DIFF
--- a/karan-resume/package.json
+++ b/karan-resume/package.json
@@ -28,6 +28,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.16.0",
+    "use-haptic": "^1.1.13",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/karan-resume/src/components/Home.tsx
+++ b/karan-resume/src/components/Home.tsx
@@ -22,6 +22,7 @@ import { MainListItems, SecondaryListItems } from './ListItems.tsx';
 import SiteStatsWidget from './SiteStatsWidget.tsx';
 import { isLandscape } from '../helpers/CommonHelpers.ts';
 import { useAppTheme, useKeyboardShortcuts } from '../hooks/CommonHooks.tsx';
+import { useHaptic } from 'use-haptic';
 
 
 function SkipLink() {
@@ -84,9 +85,10 @@ export default function Home() {
 
   const { theme, toggleTheme, isDark } = useAppTheme();
   useKeyboardShortcuts();
+  const { triggerHaptic } = useHaptic();
 
-  const toggleDrawer = () => setDrawerOpen((prev) => !prev);
-  const closeDrawer = () => setDrawerOpen(false);
+  const toggleDrawer = () => { triggerHaptic(); setDrawerOpen((prev) => !prev); };
+  const closeDrawer = () => { triggerHaptic(); setDrawerOpen(false); };
 
   return (
     <ThemeProvider theme={theme}>

--- a/karan-resume/src/components/ListItems.tsx
+++ b/karan-resume/src/components/ListItems.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
+import { useHaptic } from 'use-haptic';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -63,10 +64,11 @@ const KeyHint: React.FC<KeyHintProps> = ({ children }) => (
 export const MainListItems: React.FC = () => {
   const { pathname } = useLocation();
   const isAsherZone = pathname === '/asher-zone';
+  const { triggerHaptic } = useHaptic();
 
   return (
     <React.Fragment>
-      <ListItemButton component={NavLink} to="/" end aria-label="home, press 1">
+      <ListItemButton component={NavLink} to="/" end aria-label="home, press 1" onClick={triggerHaptic}>
         <ListItemIcon aria-hidden="true">
           <HomeIcon />
         </ListItemIcon>
@@ -74,7 +76,7 @@ export const MainListItems: React.FC = () => {
         <KeyHint>1</KeyHint>
       </ListItemButton>
 
-      <ListItemButton component={NavLink} to="/experience" aria-label="experience, press 2">
+      <ListItemButton component={NavLink} to="/experience" aria-label="experience, press 2" onClick={triggerHaptic}>
         <ListItemIcon aria-hidden="true">
           <WorkHistoryIcon />
         </ListItemIcon>
@@ -82,7 +84,7 @@ export const MainListItems: React.FC = () => {
         <KeyHint>2</KeyHint>
       </ListItemButton>
 
-      <ListItemButton component={NavLink} to="/hobbies" aria-label="hobbies, press 3">
+      <ListItemButton component={NavLink} to="/hobbies" aria-label="hobbies, press 3" onClick={triggerHaptic}>
         <ListItemIcon aria-hidden="true">
           <SportsRugbyIcon />
         </ListItemIcon>
@@ -90,7 +92,7 @@ export const MainListItems: React.FC = () => {
         <KeyHint>3</KeyHint>
       </ListItemButton>
 
-      <ListItemButton component={NavLink} to="/musings" aria-label="musings, press 4">
+      <ListItemButton component={NavLink} to="/musings" aria-label="musings, press 4" onClick={triggerHaptic}>
         <ListItemIcon aria-hidden="true">
           <TwitterIcon />
         </ListItemIcon>
@@ -103,6 +105,7 @@ export const MainListItems: React.FC = () => {
         to="/asher-zone"
         disabled={isAsherZone}
         aria-label="asher zone, press 5"
+        onClick={triggerHaptic}
       >
         <ListItemIcon aria-hidden="true">
           <PetsIcon />
@@ -112,7 +115,7 @@ export const MainListItems: React.FC = () => {
       </ListItemButton>
 
       {isAsherZone && (
-        <ListItemButton component={NavLink} to="/" aria-label="exit the asher zone">
+        <ListItemButton component={NavLink} to="/" aria-label="exit the asher zone" onClick={triggerHaptic}>
           <ListItemIcon aria-hidden="true">
             <ExitToAppIcon />
           </ListItemIcon>

--- a/karan-resume/yarn.lock
+++ b/karan-resume/yarn.lock
@@ -2425,7 +2425,7 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-react-dom@^19.2.7:
+react-dom@^19.0.0, react-dom@^19.2.7:
   version "19.2.7"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz"
   integrity sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==
@@ -2472,7 +2472,7 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^19.2.7:
+react@^19.0.0, react@^19.2.7:
   version "19.2.7"
   resolved "https://registry.npmjs.org/react/-/react-19.2.7.tgz"
   integrity sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==
@@ -2799,6 +2799,14 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-haptic@^1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/use-haptic/-/use-haptic-1.1.13.tgz#3aefaceaf98b7a79490a8c5510b5cbea767011e4"
+  integrity sha512-Kg6+MaksFTPlbAbf+WTbJPlsXt6z61LsQ1TfnGv29Q/Ewp2pmmAG6WipOMf89zDOiCZ004IHNs/iwpsxSbDa4w==
+  dependencies:
+    react "^19.0.0"
+    react-dom "^19.0.0"
 
 vite-plugin-image-optimizer@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
Experimental haptics using [`use-haptic`](https://github.com/posaune0423/use-haptic) (uses the Safari 18 `input[switch]` haptic API — fires on iOS/Android, no-ops on desktop).

## What triggers haptics
- Hamburger menu open/close (AppBar)
- FAB open/close
- Close-drawer chevron button
- All main nav list items (home, experience, hobbies, musings, asher zone, exit asher zone)

## Changes
- `yarn add use-haptic`
- `Home.tsx` — `useHaptic()` wired into `toggleDrawer` / `closeDrawer`
- `ListItems.tsx` — `useHaptic()` wired into each `MainListItems` nav button via `onClick`

https://claude.ai/code/session_0161kvMLs99s77ofepmBqsn1

---
_Generated by [Claude Code](https://claude.ai/code/session_0161kvMLs99s77ofepmBqsn1)_