### PR TITLE
Reduce haptic duration to 3ms

### DIFF
--- a/karan-resume/src/components/Home.tsx
+++ b/karan-resume/src/components/Home.tsx
@@ -85,7 +85,7 @@ export default function Home() {
 
   const { theme, toggleTheme, isDark } = useAppTheme();
   useKeyboardShortcuts();
-  const { triggerHaptic } = useHaptic();
+  const { triggerHaptic } = useHaptic(3);
 
   const toggleDrawer = () => { triggerHaptic(); setDrawerOpen((prev) => !prev); };
   const closeDrawer = () => { triggerHaptic(); setDrawerOpen(false); };

--- a/karan-resume/src/components/ListItems.tsx
+++ b/karan-resume/src/components/ListItems.tsx
@@ -64,7 +64,7 @@ const KeyHint: React.FC<KeyHintProps> = ({ children }) => (
 export const MainListItems: React.FC = () => {
   const { pathname } = useLocation();
   const isAsherZone = pathname === '/asher-zone';
-  const { triggerHaptic } = useHaptic();
+  const { triggerHaptic } = useHaptic(3);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Reduces haptic duration from 5ms (library default) to 3ms in both `Home.tsx` and `ListItems.tsx` for a crisper, more tap-like feel on Android.

https://claude.ai/code/session_0161kvMLs99s77ofepmBqsn1

---
_Generated by [Claude Code](https://claude.ai/code/session_0161kvMLs99s77ofepmBqsn1)_