### PR TITLE
Lazy-load routes and drop unused Roboto 300 weight

### DIFF
--- a/karan-resume/src/main.tsx
+++ b/karan-resume/src/main.tsx
@@ -1,16 +1,16 @@
-import '@fontsource/roboto/300.css';
 import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
-import { StrictMode } from 'react';
+import { StrictMode, lazy, Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 import { createHashRouter, RouterProvider } from 'react-router-dom';
 import Home from './components/Home.tsx';
 import HomeContent from './components/HomeContent.tsx';
-import ExperienceContent from './components/ExperienceContent.tsx';
-import HobbyContent from './components/HobbyContent.tsx';
-import AsherZoneContent from './components/AsherZoneContent.tsx';
-import MusingsContent from './components/MusingsContent.tsx';
+
+const ExperienceContent = lazy(() => import('./components/ExperienceContent.tsx'));
+const HobbyContent = lazy(() => import('./components/HobbyContent.tsx'));
+const AsherZoneContent = lazy(() => import('./components/AsherZoneContent.tsx'));
+const MusingsContent = lazy(() => import('./components/MusingsContent.tsx'));
 
 const router = createHashRouter([
   {
@@ -18,10 +18,10 @@ const router = createHashRouter([
     element: <Home />,
     children: [
       { index: true, element: <HomeContent /> },
-      { path: 'experience', element: <ExperienceContent /> },
-      { path: 'hobbies', element: <HobbyContent /> },
-      { path: 'asher-zone', element: <AsherZoneContent /> },
-      { path: 'musings', element: <MusingsContent /> },
+      { path: 'experience', element: <Suspense fallback={null}><ExperienceContent /></Suspense> },
+      { path: 'hobbies', element: <Suspense fallback={null}><HobbyContent /></Suspense> },
+      { path: 'asher-zone', element: <Suspense fallback={null}><AsherZoneContent /></Suspense> },
+      { path: 'musings', element: <Suspense fallback={null}><MusingsContent /></Suspense> },
     ],
   },
 ]);


### PR DESCRIPTION
## What
- Lazy-load `ExperienceContent`, `HobbyContent`, `AsherZoneContent`, and `MusingsContent` via `React.lazy` + `Suspense`
- Drop `@fontsource/roboto/300.css` — weight 300 is unused (site uses 400/500/700)

## Why
The home page was parsing JS for all routes on every load. Route splitting moves those chunks out of the critical path — they only download when the user navigates to that route.

## Bundle impact
Before: single JS entry ~360KB + all route code inlined  
After: same 360KB MUI core, route chunks offloaded (1–16KB each, loaded on demand)

The weekly `stats.yml` Lighthouse run will measure the real LCP delta once deployed.

https://claude.ai/code/session_0161kvMLs99s77ofepmBqsn1

---
_Generated by [Claude Code](https://claude.ai/code/session_0161kvMLs99s77ofepmBqsn1)_