### PR TITLE
Revert lazy-loaded routes (caused LCP regression)

### DIFF
--- a/karan-resume/src/main.tsx
+++ b/karan-resume/src/main.tsx
@@ -1,16 +1,15 @@
 import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
-import { StrictMode, lazy, Suspense } from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { createHashRouter, RouterProvider } from 'react-router-dom';
 import Home from './components/Home.tsx';
 import HomeContent from './components/HomeContent.tsx';
-
-const ExperienceContent = lazy(() => import('./components/ExperienceContent.tsx'));
-const HobbyContent = lazy(() => import('./components/HobbyContent.tsx'));
-const AsherZoneContent = lazy(() => import('./components/AsherZoneContent.tsx'));
-const MusingsContent = lazy(() => import('./components/MusingsContent.tsx'));
+import ExperienceContent from './components/ExperienceContent.tsx';
+import HobbyContent from './components/HobbyContent.tsx';
+import AsherZoneContent from './components/AsherZoneContent.tsx';
+import MusingsContent from './components/MusingsContent.tsx';
 
 const router = createHashRouter([
   {
@@ -18,10 +17,10 @@ const router = createHashRouter([
     element: <Home />,
     children: [
       { index: true, element: <HomeContent /> },
-      { path: 'experience', element: <Suspense fallback={null}><ExperienceContent /></Suspense> },
-      { path: 'hobbies', element: <Suspense fallback={null}><HobbyContent /></Suspense> },
-      { path: 'asher-zone', element: <Suspense fallback={null}><AsherZoneContent /></Suspense> },
-      { path: 'musings', element: <Suspense fallback={null}><MusingsContent /></Suspense> },
+      { path: 'experience', element: <ExperienceContent /> },
+      { path: 'hobbies', element: <HobbyContent /> },
+      { path: 'asher-zone', element: <AsherZoneContent /> },
+      { path: 'musings', element: <MusingsContent /> },
     ],
   },
 ]);


### PR DESCRIPTION
Reverts the `React.lazy` + `Suspense` route splitting from #45 — it caused LCP to increase from 3.2s to 4.9s. The Suspense fallback delays rendering until the chunk arrives, which hurts more than the bundle savings help for a hash-routed SPA.

Keeps the Roboto 300 weight removal since that's unrelated and still valid.

https://claude.ai/code/session_0161kvMLs99s77ofepmBqsn1

---
_Generated by [Claude Code](https://claude.ai/code/session_0161kvMLs99s77ofepmBqsn1)_