### PR TITLE
chore: migrate github pulse to mistral console api

### DIFF
--- a/.github/workflows/pulse.yml
+++ b/.github/workflows/pulse.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Generate pulse summary
         env:
-          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/summarize.py
 

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -1,6 +1,6 @@
 """
 Fetches recent public commits for karanshukla and generates a witty summary
-via GitHub Models (Mistral). Writes the result to karan-resume/src/data/pulse.json.
+via Mistral Console API. Writes the result to karan-resume/src/data/pulse.json.
 Run by the pulse.yml GitHub Actions workflow every 3 days.
 """
 
@@ -14,9 +14,9 @@ from datetime import datetime, timezone, timedelta
 GITHUB_USER = "karanshukla"
 OUTPUT_PATH = "karan-resume/src/data/pulse.json"
 
-token = os.environ.get("GH_MODELS_TOKEN")
+token = os.environ.get("MISTRAL_API_KEY")
 if not token:
-    print("GH_MODELS_TOKEN is not set", file=sys.stderr)
+    print("MISTRAL_API_KEY is not set", file=sys.stderr)
     sys.exit(1)
 
 github_token = os.environ.get("GITHUB_TOKEN")
@@ -114,9 +114,9 @@ if not push_summaries:
 
 commit_text = "\n\n".join(push_summaries)
 
-# 2. Call GitHub Models (Mistral)
+# 2. Call Mistral Console API
 payload = json.dumps({
-    "model": "mistral-ai/mistral-medium-2505",
+    "model": "mistral-medium-2505",
     "messages": [
         {
             "role": "system",
@@ -139,7 +139,7 @@ payload = json.dumps({
 }).encode()
 
 model_req = urllib.request.Request(
-    "https://models.github.ai/inference/chat/completions",
+    "https://api.mistral.ai/v1/chat/completions",
     data=payload,
     headers={
         "Authorization": f"Bearer {token}",

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -116,7 +116,7 @@ commit_text = "\n\n".join(push_summaries)
 
 # 2. Call Mistral Console API
 payload = json.dumps({
-    "model": "mistral-medium-2505",
+    "model": "mistral-medium-3.5",
     "messages": [
         {
             "role": "system",


### PR DESCRIPTION
## Summary

- Swaps `GH_MODELS_TOKEN` → `MISTRAL_API_KEY` in both the script and the workflow env block
- Updates the API endpoint from `https://models.github.ai/inference/chat/completions` to `https://api.mistral.ai/v1/chat/completions`
- Drops the vendor prefix from the model id (`mistral-ai/mistral-medium-2505` → `mistral-medium-2505`)

The `MISTRAL_API_KEY` repository secret is already configured.

## Test plan

- [x] Trigger the `Update GitHub Pulse` workflow manually via `workflow_dispatch` and confirm `pulse.json` is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GyRxLHw9ULkTF9NFxRKuU

---
_Generated by [Claude Code](https://claude.ai/code/session_015GyRxLHw9ULkTF9NFxRKuU)_