### PR TITLE
Increase LLM pulse summary length to 3-4 sentences

### DIFF
--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -129,8 +129,8 @@ payload = json.dumps(
                 "role": "system",
                 "content": (
                     "you are a witty technical writer. summarize what a developer named karan "
-                    "has been working on recently based on their commit messages. write 2-3 simple "
-                    "sentences, all lowercase, casual and specific. stay under 300 characters total. "
+                    "has been working on recently based on their commit messages. write 3-4 simple "
+                    "sentences, all lowercase, casual and specific. stay under 450 characters total. "
                     'no filler phrases like "it looks like" or "the developer". '
                     "ignore merged prs, version bumps, dependency updates, and workflow changes. "
                     "focus only on actual code changes: new features, bug fixes, refactors"
@@ -141,7 +141,7 @@ payload = json.dumps(
                 "content": f"recent commits:\n{commit_text}",
             },
         ],
-        "max_tokens": 180,
+        "max_tokens": 270,
         "temperature": 0.7,
     }
 ).encode()


### PR DESCRIPTION
## Summary

- Bumped the sentence target from 2-3 to 3-4 in the Mistral system prompt
- Raised the character limit from 300 to 450
- Raised `max_tokens` from 180 to 270 to give the model room to actually produce the extra sentence

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtcZyAXWmMzDAeLdqGALEp)_