### PR TITLE
Swap homepage project cards to openresto and asher-cli

### DIFF
--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -64,20 +64,21 @@ function HomeContent() {
             <Grid size={{ xs: 12, md: 6 }} sx={{ display: 'flex' }}>
               <Paper sx={{ p: 3, width: '100%', display: 'flex', flexDirection: 'column' }}>
                 <Typography variant="h6" gutterBottom>
-                  navyfragen
+                  openresto
                 </Typography>
                 <Typography variant="subtitle2" sx={{ color: 'text.secondary' }} gutterBottom>
-                  bluesky q&a messaging platform
+                  open source restaurant booking system
                 </Typography>
                 <Typography variant="body1" sx={{ flexGrow: 1 }}>
-                  anonymous q&a platform on bluesky's at protocol - users receive questions and post
-                  answers to their followers. node.js/react (mantine ui), waf-protected, with a
-                  microservice for answer card images and crons for notification processing
+                  a self-hosted, cloudless table booking system for restaurants - no fees, no data
+                  collection, no vendor lock-in. asp.net backend with sqlite, a react native mobile
+                  frontend, and full brand customisability, fully dockerised for quick
+                  self-deployment
                 </Typography>
                 <RepoStats
                   owner="karanshukla"
-                  repo="navyfragen-app"
-                  url="https://github.com/karanshukla/navyfragen-app"
+                  repo="openresto"
+                  url="https://github.com/karanshukla/openresto"
                 />
               </Paper>
             </Grid>

--- a/src/tests/HomeContent.test.tsx
+++ b/src/tests/HomeContent.test.tsx
@@ -48,7 +48,7 @@ describe('HomeContent', () => {
 
   it('renders both project card titles', () => {
     render(<HomeContent />);
-    expect(screen.getByText('navyfragen')).toBeInTheDocument();
+    expect(screen.getByText('openresto')).toBeInTheDocument();
     expect(screen.getByText('asher-cli')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- Replaced the navyfragen homepage project card with openresto (description/tech pulled from the existing ExperienceContent entry)
- Kept asher-cli as the second featured project
- Updated the HomeContent test's title assertion to match

## Why
openresto and asher-cli are the most popular projects, so they're a better showcase on the homepage than navyfragen.

## Test plan
- [x] `yarn test:run src/tests/HomeContent.test.tsx` — 8/8 passing
- [x] Reviewed diff for accuracy against ExperienceContent.tsx's openresto entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)