### PR TITLE
Fix ESLint crash on TypeScript 7 via TS6 API shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/aria-query": "^5.0.4",
+    "@typescript/typescript6": "^6.0.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.3.1",
@@ -58,7 +59,8 @@
     "vitest": "^4.1.9"
   },
   "resolutions": {
-    "vitest/vite": "^8.1.1"
+    "vitest/vite": "^8.1.1",
+    "typescript-eslint/**/typescript": "npm:@typescript/typescript6@^6.0.2"
   },
   "browserslist": {
     "production": [

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -72,21 +72,28 @@ export default function Home() {
   const [drawerOpen, setDrawerOpen] = React.useState(!isMobile && isLandscape());
   const location = useLocation();
 
+  // Adjusted during render rather than in an effect, per
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [prevPathname, setPrevPathname] = React.useState(location.pathname);
+  const [prevIsMobile, setPrevIsMobile] = React.useState(isMobile);
+
+  // On mobile, close drawer when the route changes (nav tap)
+  if (location.pathname !== prevPathname) {
+    setPrevPathname(location.pathname);
+    if (isMobile) setDrawerOpen(false);
+  }
+
+  // Re-sync when breakpoint flips (e.g. device rotation)
+  if (isMobile !== prevIsMobile) {
+    setPrevIsMobile(isMobile);
+    setDrawerOpen(!isMobile && isLandscape());
+  }
+
   // Scroll to top on route change
   React.useEffect(() => {
     const el = document.getElementById('main-content');
     if (el?.scrollTo) el.scrollTo({ top: 0 });
   }, [location.pathname]);
-
-  // On mobile, close drawer when the route changes (nav tap)
-  React.useEffect(() => {
-    if (isMobile) setDrawerOpen(false);
-  }, [location.pathname, isMobile]);
-
-  // Re-sync when breakpoint flips (e.g. device rotation)
-  React.useEffect(() => {
-    setDrawerOpen(!isMobile && isLandscape());
-  }, [isMobile]);
 
   const { theme, toggleTheme, isDark } = useAppTheme();
   useKeyboardShortcuts();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1194,6 +1194,11 @@
     "@typescript-eslint/types" "8.63.0"
     eslint-visitor-keys "^5.0.0"
 
+"@typescript/old@npm:typescript@^6":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+
 "@typescript/typescript-aix-ppc64@7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz#cdc7ce81d60f1e09034960ddfb1fb880d7a776b6"
@@ -1293,6 +1298,13 @@
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz#cf3b7b0d6ce5635daca4c8e01c189cdcde47ec3c"
   integrity sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==
+
+"@typescript/typescript6@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@typescript/typescript6/-/typescript6-6.0.2.tgz#79e0e47492564c83f8602013d7dd10d5ebc51a8c"
+  integrity sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==
+  dependencies:
+    "@typescript/old" "npm:typescript@^6"
 
 "@ungap/structured-clone@^1.0.0":
   version "1.3.2"
@@ -3490,6 +3502,13 @@ typescript@^7.0.0:
     "@typescript/typescript-sunos-x64" "7.0.2"
     "@typescript/typescript-win32-arm64" "7.0.2"
     "@typescript/typescript-win32-x64" "7.0.2"
+
+"typescript@npm:@typescript/typescript6@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@typescript/typescript6/-/typescript6-6.0.2.tgz#79e0e47492564c83f8602013d7dd10d5ebc51a8c"
+  integrity sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==
+  dependencies:
+    "@typescript/old" "npm:typescript@^6"
 
 undici@^7.25.0:
   version "7.28.0"


### PR DESCRIPTION
## Summary
- `yarn lint` crashed with `Cannot read properties of undefined (reading 'Cjs')` because TypeScript 7.0 ships only the native `tsc` binary with no compiler API (that lands in 7.1) — but `typescript-eslint`'s `typescript-estree` needs that API and was resolving the root `typescript` package.
- Added a yarn resolution that scopes `typescript-eslint`'s dependency subtree to resolve `typescript` as `@typescript/typescript6` (Microsoft's official TS6-API compatibility shim), while leaving the root `typescript` package at 7.0.2 for the actual build/`tsc -b`. No downgrade of the real compiler.
- Fixing the crash unmasked two pre-existing `react-hooks/set-state-in-effect` errors in `Home.tsx` (calling `setDrawerOpen` synchronously inside effects). Refactored both into render-time state adjustments per the [React docs' recommended pattern](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) — same behavior, no extra cascading render.

## Why
Keeps TypeScript on the bleeding-edge native v7 compiler for builds while unblocking lint, rather than downgrading TypeScript project-wide.

## Test plan
- [x] `yarn lint` — clean, no errors
- [x] `yarn test:run` — 99 passed | 3 skipped
- [x] `yarn build` — succeeds, root `typescript` stays at 7.0.2
- [x] Verified nested alias: `node_modules/typescript-eslint/node_modules/typescript` resolves to `@typescript/typescript6` while root stays 7.0.2
- [x] Live-tested drawer behavior in dev server (mobile close-on-nav, manual toggle) via DOM event dispatch — matches pre-refactor behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)