### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] Build succeeds locally (`npm run build`)
+- [ ] Checked in the browser at relevant breakpoints (mobile/desktop)
+- [ ] CI checks pass (build, coverage, PR checks)
+
+## Screenshots
+
+<!-- For visual changes, include before/after screenshots -->
+
+## Checklist
+
+- [ ] No secrets or API keys committed
+- [ ] No noticeable regression in Lighthouse/perf for changed pages


### PR DESCRIPTION
Adds `.github/pull_request_template.md` covering build/screenshot/perf checks so PRs start with a consistent structure.