### PR TITLE
fix: authenticate scheduled workflow pushes with GitHub App token

### DIFF
--- a/.github/workflows/pulse.yml
+++ b/.github/workflows/pulse.yml
@@ -17,10 +17,18 @@ jobs:
   pulse:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Generate pulse summary
         env:

--- a/.github/workflows/standard-site.yml
+++ b/.github/workflows/standard-site.yml
@@ -21,8 +21,17 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Publish records to PDS
         env:

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -17,10 +17,18 @@ jobs:
   stats:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4


### PR DESCRIPTION
## Summary

- The new "Protect Main" repository ruleset requires all changes to go through a PR, which broke direct-to-main pushes in the three scheduled data-refresh workflows (they authenticate as `github-actions[bot]` via the default `GITHUB_TOKEN`, which isn't a valid bypass actor on the ruleset).
- Adds a "Generate app token" step (using `actions/create-github-app-token`) to `pulse.yml`, `stats.yml`, and `standard-site.yml` that mints a short-lived token from a dedicated GitHub App, and passes it to `actions/checkout` so the subsequent `git push` authenticates as that App instead.
- The App has been installed on this repo with `Contents: read & write` only, and added to the ruleset's bypass list — this avoids using a long-lived personal access token.

## Changes

- `.github/workflows/pulse.yml`: mint app token before checkout, use it for push auth
- `.github/workflows/stats.yml`: same
- `.github/workflows/standard-site.yml`: same

## Testing

- [x] Confirmed root cause via failed run log (`GH013: Repository rule violations ... Changes must be made through a pull request`)
- [ ] Build succeeds locally (`npm run build`)
- [ ] CI checks pass (build, coverage, PR checks)
- [ ] After merge: trigger each workflow via `workflow_dispatch` to confirm the push now succeeds

## Screenshots

N/A (CI/workflow-only change)

## Checklist

- [x] No secrets or API keys committed (App ID / private key already stored as repo secrets: `APP_ID`, `APP_PRIVATE_KEY`)
- [x] No noticeable regression in Lighthouse/perf for changed pages (not applicable)