### PR TITLE
fix: serialize site-deploy workflows to stop gh-pages/main race

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -19,6 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
+          ref: main # Always deploy the live tip of main, not the triggering commit
           fetch-depth: 0 # Important for GitHub Pages
 
       - name: Setup Node.js

--- a/.github/workflows/pulse.yml
+++ b/.github/workflows/pulse.yml
@@ -13,6 +13,10 @@ on:
     - cron: '0 0 */3 * *'
   workflow_dispatch:
 
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
 jobs:
   pulse:
     runs-on: ubuntu-latest
@@ -27,6 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
+          ref: main # Always build from the live tip of main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -13,6 +13,10 @@ on:
     - cron: '0 2 * * 1'  # Every Monday at 02:00 UTC
   workflow_dispatch:
 
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
 jobs:
   stats:
     runs-on: ubuntu-latest
@@ -27,6 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
+          ref: main # Always build from the live tip of main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Summary

- `main.yml`, `pulse.yml`, and `stats.yml` each independently commit data, build, and deploy to GitHub Pages. Running concurrently, they raced and produced two real failures observed in production right after merging #61:
  - `stats.yml`'s `git push` was rejected `non-fast-forward` because `pulse.yml` committed `pulse.json` to `main` in between its checkout and push.
  - `main.yml`'s "Deploy on Push" run (triggered by the #61 merge commit) finished *after* `pulse.yml`'s deploy and force-pushed `gh-pages` with an older tree — `actions/checkout` pins to the commit that triggered the push event, not the live tip of `main`, so it silently reverted the fresh `pulse.json` that had landed moments earlier.
- Fix: all three workflows now share a `pages-deploy` concurrency group (`cancel-in-progress: false`) so they queue instead of racing, and their checkouts are pinned to `ref: main` so whichever runs always builds from the current tip rather than a stale triggering commit.

## Changes

- `.github/workflows/main.yml`: add concurrency group, pin checkout to `ref: main`
- `.github/workflows/pulse.yml`: same
- `.github/workflows/stats.yml`: same

## Testing

- [x] Root cause confirmed via API: `gh-pages` branch's last deploy commit message was stamped with the pre-pulse-fix merge SHA, not the later pulse.json commit
- [x] Root cause of `stats.yml` failure confirmed via run logs (`non-fast-forward` rejection)
- [ ] After merge: trigger `pulse.yml` then `stats.yml` back-to-back via `workflow_dispatch` and confirm both complete and the live site reflects the latest data without one clobbering the other

## Screenshots

N/A (CI/workflow-only change)

## Checklist

- [x] No secrets or API keys committed
- [x] No noticeable regression in Lighthouse/perf for changed pages (not applicable)