### PR TITLE
ci: upgrade Node 20 → 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn' # Use yarn cache
 
       - name: Install dependencies

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/pulse.yml
+++ b/.github/workflows/pulse.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Upgrades the Node.js version pinned across all GitHub Actions workflows from **Node 20** to **Node 24** (current LTS).

## Changes

Bumps `actions/setup-node` `node-version` in:

- `.github/workflows/main.yml`
- `.github/workflows/pr-check.yml`
- `.github/workflows/pulse.yml`
- `.github/workflows/stats.yml`

`standard-site.yml` is Python-only and has no Node step, so it was untouched. There is no `.nvmrc`, `.node-version`, or `package.json#engines` in the repo.

## Verification

Ran the full suite locally on Node `v24.13.1`:

\`\`\`
Test Files  15 passed | 1 skipped (16)
     Tests  99 passed | 3 skipped (102)