### PR TITLE
chore: declare repo-level Claude Code plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@
 .env.development.local
 .env.test.local
 .env.production.local
-.claude/
+.claude/*
+!.claude/settings.json
+.claude/settings.local.json
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
Adds typescript-lsp, github, frontend-design, context7, and claude-md-management to enabledPlugins, and un-ignores .claude/settings.json (keeping settings.local.json gitignored) so anyone cloning the repo with Claude Code picks up the relevant skills/LSPs automatically.

## Summary

<!-- What does this PR change, and why? -->

## Changes

-

## Testing

- [ ] Build succeeds locally (`npm run build`)
- [ ] Checked in the browser at relevant breakpoints (mobile/desktop)
- [ ] CI checks pass (build, coverage, PR checks)

## Screenshots

<!-- For visual changes, include before/after screenshots -->

## Checklist

- [ ] No secrets or API keys committed
- [ ] No noticeable regression in Lighthouse/perf for changed pages
