### PR TITLE
fix(deps): patch brace-expansion security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
   },
   "resolutions": {
     "vitest/vite": "^8.1.1",
-    "typescript-eslint/**/typescript": "npm:@typescript/typescript6@^6.0.2"
+    "typescript-eslint/**/typescript": "npm:@typescript/typescript6@^6.0.2",
+    "brace-expansion": "^5.0.8",
+    "react-router": "^8.3.0"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
   "resolutions": {
     "vitest/vite": "^8.1.1",
     "typescript-eslint/**/typescript": "npm:@typescript/typescript6@^6.0.2",
-    "brace-expansion": "^5.0.8",
-    "react-router": "^8.3.0"
+    "brace-expansion": "^5.0.8"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,10 +1592,10 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie-es@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/cookie-es/-/cookie-es-3.1.1.tgz#c4a8a16cf88cb5a185b23f4a61d6e9a85eb53287"
-  integrity sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==
+cookie@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
+  integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
 
 cosmiconfig@^7.0.0:
   version "7.1.0"
@@ -3102,12 +3102,13 @@ react-router-dom@^7.18.1:
   dependencies:
     react-router "7.18.1"
 
-react-router@7.18.1, react-router@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-8.3.0.tgz#b7bc69c3e3833ba79ebf892aef03d62b649508f8"
-  integrity sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==
+react-router@7.18.1:
+  version "7.18.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.18.1.tgz#61259d1594b95c1ace299ee4c57453570f0c22f1"
+  integrity sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==
   dependencies:
-    cookie-es "^3.1.1"
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
 
 react-transition-group@^4.4.5:
   version "4.4.5"
@@ -3235,6 +3236,11 @@ semver@^7.7.3, semver@^7.8.5:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
+
+set-cookie-parser@^2.6.0:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz#ccd08673a9ae5d2e44ea2a2de25089e67c7edf68"
+  integrity sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==
 
 sharp@^0.35.2:
   version "0.35.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,10 +1497,10 @@ bidi-js@^1.0.3:
   dependencies:
     require-from-string "^2.0.2"
 
-brace-expansion@^5.0.5:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
-  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+brace-expansion@^5.0.5, brace-expansion@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -1592,10 +1592,10 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
-  integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
+cookie-es@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/cookie-es/-/cookie-es-3.1.1.tgz#c4a8a16cf88cb5a185b23f4a61d6e9a85eb53287"
+  integrity sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==
 
 cosmiconfig@^7.0.0:
   version "7.1.0"
@@ -3102,13 +3102,12 @@ react-router-dom@^7.18.1:
   dependencies:
     react-router "7.18.1"
 
-react-router@7.18.1:
-  version "7.18.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.18.1.tgz#61259d1594b95c1ace299ee4c57453570f0c22f1"
-  integrity sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==
+react-router@7.18.1, react-router@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-8.3.0.tgz#b7bc69c3e3833ba79ebf892aef03d62b649508f8"
+  integrity sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==
   dependencies:
-    cookie "^1.0.1"
-    set-cookie-parser "^2.6.0"
+    cookie-es "^3.1.1"
 
 react-transition-group@^4.4.5:
   version "4.4.5"
@@ -3236,11 +3235,6 @@ semver@^7.7.3, semver@^7.8.5:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
-
-set-cookie-parser@^2.6.0:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz#ccd08673a9ae5d2e44ea2a2de25089e67c7edf68"
-  integrity sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==
 
 sharp@^0.35.2:
   version "0.35.3"


### PR DESCRIPTION
## Summary

Scheduled dependency audit found 2 high-severity advisories affecting this repo. One is fixed here; the other is blocked upstream (details below).

## Changes

- Pin `brace-expansion` to `^5.0.8` — the installed transitive version (`<=5.0.7`, pulled in via `eslint`/`typescript-eslint`'s `minimatch`) is vulnerable to [CVE-2026-14257](https://github.com/advisories/GHSA-mh99-v99m-4gvg), a DoS via unbounded expansion length that crashes the Node process with an uncatchable OOM error. Dev-dependency only (ESLint tooling), not shipped to production. **Fixed** via a yarn `resolutions` entry.

### Not fixed here: `react-router` CSRF advisory (GHSA-qwww-vcr4-c8h2)

`react-router-dom@7.18.1` (latest published) depends on `react-router@7.18.1`, which is vulnerable to a CSRF bypass in unstable RSC-mode action handling — the advisory itself notes this only affects apps using the unstable RSC APIs, which this app doesn't (it's a client-side SPA using `createHashRouter`).

I initially force-pinned `react-router` to the patched `8.3.0` via a resolution, and it passed build/lint/tests locally — but CI caught what my local check didn't: `react-router@8.3.0` requires Node `>=22.22.0`, while this repo's CI (`main`, `pr-check`, `pulse`, `stats` workflows) pins Node 20, with no `.nvmrc` or `engines` field anywhere in the repo. `yarn install` failed in CI with `error react-router@8.3.0: The engine "node" is incompatible with this module`. I reverted that override rather than also bump the Node baseline across four workflow files, since that's a separate infra decision outside the scope of a dependency-security PR. Given the advisory's real-world exposure here is already effectively nil (no RSC usage), leaving it open until `react-router-dom` publishes a release with the compatible dependency (or the Node baseline is deliberately bumped) seemed the safer call.

`yarn audit`: 2 advisories / 6 findings → **1 advisory / 1 finding** (the `react-router` one above) after this PR.

## Testing

- [x] Build succeeds locally (`yarn build`)
- [x] `yarn lint` passes
- [x] `yarn test:run` — 99 passed, 3 skipped, no failures
- [x] `yarn audit` — 1 high (`react-router`, tracked above; down from 2 advisories)
- [ ] Checked in the browser at relevant breakpoints (mobile/desktop) — no UI changes, dependency-only PR
- [x] CI checks pass (build, coverage, PR checks)

## Screenshots

N/A — dependency-only change, no UI/behavior change.

## Checklist

- [x] No secrets or API keys committed
- [x] No noticeable regression in Lighthouse/perf for changed pages (no code changes)
