### PR TITLE
Fix brace-expansion DoS vulnerability (CVE-2026-69152)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "resolutions": {
     "vitest/vite": "^8.1.1",
     "typescript-eslint/**/typescript": "npm:@typescript/typescript6@^6.0.2",
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,10 +1497,10 @@ bidi-js@^1.0.3:
   dependencies:
     require-from-string "^2.0.2"
 
-brace-expansion@^5.0.5, brace-expansion@^5.0.8:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
-  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
+brace-expansion@^5.0.5, brace-expansion@^5.0.9:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Summary
- Bumps the pinned `brace-expansion` resolution from `^5.0.8` to `^5.0.9`, fixing [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) / CVE-2026-69152 (high severity).
- The `5.0.8` mitigation for the prior brace-expansion DoS (CVE-2026-14257) was incomplete: unbounded intermediate arrays in `expand()` still let attacker-controlled glob/brace patterns exhaust memory or stall the event loop. `5.0.9` bounds those intermediate arrays too.
- This dependency is pulled in transitively via `eslint`/`typescript-eslint`'s `minimatch` chain (dev tooling only), pinned in `package.json` `resolutions`.
- `yarn audit` now reports 0 vulnerabilities (previously flagged this as the sole finding).

## Test plan
- [x] `yarn install` — lockfile updated, resolves to `brace-expansion@5.0.9`
- [x] `yarn audit` — 0 vulnerabilities
- [x] `yarn lint` — passes
- [x] `yarn test:run` — 99 passed, 3 skipped (pre-existing skips)
- [x] `yarn build` — succeeds

Found and fixed as part of a routine scheduled dependency/security sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Etf4QRsQG1WhzBPkcMXCkB)_