### PR TITLE
fix(deps): patch nanoid high-severity DoS advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "resolutions": {
     "vitest/vite": "^8.1.1",
     "typescript-eslint/**/typescript": "npm:@typescript/typescript6@^6.0.2",
-    "brace-expansion": "^5.0.9"
+    "brace-expansion": "^5.0.9",
+    "nanoid": "^3.3.18"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,10 +3009,10 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.16:
-  version "3.3.17"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
-  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
+nanoid@^3.3.16, nanoid@^3.3.18:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## Summary

Scheduled dependency audit found one security advisory: `nanoid@3.3.17` (transitive, via `vite > postcss > nanoid` and `vitest > vite > postcss > nanoid`) is flagged high severity by `yarn audit` — custom generators can loop indefinitely when `size` is 0 (npm advisory 1139427). Patched in `>=3.3.18`.

## Changes

- Added a `resolutions` entry pinning `nanoid` to `^3.3.18`, the smallest fix on the already-in-use 3.x line (avoids an unrelated major bump to nanoid 6.x, which the direct dependents don't request).
- Ran `yarn install` to regenerate `yarn.lock` with the pinned version.
- No source code changes — this is a transitive dependency only, not imported directly.

## Audit results (informational, no other action taken)

All other outdated packages found by `yarn outdated` are ordinary minor/patch version drift with **no security advisories**, so left untouched per the audit's security-only scope:

| Package | Current → Latest | Type |
|---|---|---|
| @fontsource/roboto | 5.2.10 → 5.3.0 | minor |
| @mui/icons-material | 9.2.0 → 9.3.1 | minor |
| @mui/material | 9.2.0 → 9.3.1 | minor |
| @testing-library/jest-dom | 6.9.1 → 7.0.1 | major |
| @testing-library/user-event | 14.6.1 → 14.6.5 | patch |
| @types/react | 19.2.17 → 19.2.18 | patch |
| @types/react-dom | 19.2.3 → 19.2.4 | patch |
| @vitejs/plugin-react-swc | 4.3.1 → 4.3.3 | patch |
| eslint | 10.7.0 → 10.8.1 | patch |
| eslint-plugin-react-refresh | 0.5.3 → 0.5.4 | patch |
| globals | 17.7.0 → 17.11.0 | minor |
| jsdom | 29.1.1 → 30.0.1 | major |
| prettier | 3.9.5 → 3.9.6 | patch |
| react / react-dom | 19.2.7 → 19.2.8 | patch |
| typescript-eslint | 8.64.0 → 8.67.0 | minor |
| vite | 8.1.4 → 8.2.1 | minor |
| zustand | 5.0.14 → 5.0.15 | patch |

## Testing

- [x] Build succeeds locally (`yarn build`)
- [x] `yarn lint` passes
- [x] `yarn test:run` passes (99 passed, 3 skipped)
- [x] `yarn audit` — 0 vulnerabilities (was 2 high before this change)
- [ ] Checked in the browser at relevant breakpoints (mobile/desktop) — not applicable, no UI change
- [ ] CI checks pass (build, coverage, PR checks)

Note: `yarn format:check` reports pre-existing formatting drift in 23 files unrelated to this change (not touched by this PR).

## Screenshots

N/A — dependency-only change, no UI impact.

## Checklist

- [x] No secrets or API keys committed
- [x] No noticeable regression in Lighthouse/perf for changed pages (transitive dep only)


---
_Generated by [Claude Code](https://claude.ai/code/session_0124Mb44pDE7wp5KjbWeYZgi)_