### PR TITLE
ci: match scoped dependency titles like fix(web): and chore(frontend):

### DIFF
--- a/.github/workflows/dependency-automerge.yml
+++ b/.github/workflows/dependency-automerge.yml
@@ -38,7 +38,7 @@ jobs:
             # The Claude dependency-update routine commits under this account rather
             # than a bot identity, so it's identified by title shape instead of actor.
             # Anything mentioning "major"/"breaking" is left for manual merge.
-            if printf '%s' "$TITLE" | grep -Eiq '^(chore|fix)\(deps|^chore:.*(bump|dependenc)|^fix:.*(dependenc|advisory|CVE|vulnerab)'; then
+            if printf '%s' "$TITLE" | grep -Eiq '^(chore|fix)(\([a-z0-9/_-]+\))?:.*(dependenc|advisory|CVE|vulnerab|bump)'; then
               if ! printf '%s %s' "$TITLE" "$BODY" | grep -Eiq '\b(major|breaking)\b'; then
                 safe=true
               fi


### PR DESCRIPTION
The title match only accepted `fix(deps)`, bare `fix:` or `chore:`, so dependency PRs from the Claude routine using scoped prefixes (`fix(web):`, `chore(frontend):`) were silently skipped. bluejays-space#219 hit exactly this: a clean satori/fflate patch bump with all checks green that had to be merged by hand.

Widens the prefix to accept any conventional-commit scope while still requiring a dependency keyword (`dependenc`, `advisory`, `CVE`, `vulnerab`, `bump`). Verified against real PR titles from these repos: all 8 genuine dependency PRs match, and feature/refactor/ci titles still don't. The `major`/`breaking` gate is unchanged and still blocks things like "13 minor/patch and 5 major bumps".