### PR TITLE
fix(ci): only scan the PR title for major/breaking in dependency auto-merge

### DIFF
--- a/.github/workflows/dependency-automerge.yml
+++ b/.github/workflows/dependency-automerge.yml
@@ -24,7 +24,6 @@ jobs:
         id: decide
         env:
           TITLE: ${{ github.event.pull_request.title }}
-          BODY: ${{ github.event.pull_request.body }}
           ACTOR: ${{ github.event.pull_request.user.login }}
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           DEPENDABOT_UPDATE_TYPE: ${{ steps.dependabot-metadata.outputs.update-type }}
@@ -38,8 +37,10 @@ jobs:
           elif [ "$ACTOR" = "karanshukla" ]; then
             # The dependency-update routine commits under this account rather than a
             # bot identity. The `dependencies` label is the reliable signal; the title
-            # pattern is a fallback for when it is missing. Either way, anything
-            # mentioning "major"/"breaking" is left for manual merge.
+            # pattern is a fallback for when it is missing. Either way, a title
+            # mentioning "major"/"breaking" is left for manual merge. Only the
+            # title is scanned -- dependency-audit bodies routinely mention other
+            # packages' major versions, which used to veto safe patch-level PRs.
             matched=false
             case ",$LABELS," in
               *,dependencies,*) matched=true ;;
@@ -50,7 +51,7 @@ jobs:
               fi
             fi
             if [ "$matched" = true ]; then
-              if ! printf '%s %s' "$TITLE" "$BODY" | grep -Eiq '\b(major|breaking)\b'; then
+              if ! printf '%s' "$TITLE" | grep -Eiq '\b(major|breaking)\b'; then
                 safe=true
               fi
             fi


### PR DESCRIPTION
## Problem

The `Decide eligibility` step vetoed auto-merge if `major` or `breaking` appeared anywhere in the PR **title or body**:

```sh
if ! printf '%s %s' "$TITLE" "$BODY" | grep -Eiq '\b(major|breaking)\b'; then
```

Dependency PRs routinely mention *other* packages' major versions in the body — audit summaries, "remaining outdated" tables, and even sentences explicitly stating the change is **not** breaking (`breaking-change` matches `\bbreaking\b`, since `-` is a word boundary).

The result is a silent no-op: the job succeeds at deciding *not* to merge, the `automerge` check reports green, and nothing indicates the PR was skipped.

## Fix

Scan the **title** only — the deliberate one-line summary of what the PR does — and drop the now-unused `BODY` env var.

## Behaviour

Verified by extracting the patched step and running it:

| Case | Before | After |
|---|---|---|
| Patch-level dep PR whose body mentions other majors | ❌ skipped | ✅ eligible |
| `major` / `breaking` in the **title** | ❌ skipped | ❌ skipped |
| No `dependencies` label, CVE title fallback | ✅ | ✅ |
| Unrelated PR, no label | ❌ | ❌ |
| Non-`karanshukla` contributor | ❌ | ❌ |
| Dependabot semver-patch / semver-minor | ✅ | ✅ |
| Dependabot semver-major | ❌ | ❌ |

Only the first row changes. Every other gate — actor, label/title match, dependabot semver scoping, same-repo base — is untouched.

## Tradeoff

A PR titled innocuously whose body describes a breaking change would now be eligible. The dependabot path is unaffected (it is gated on semver metadata, not prose). For the `karanshukla` path the title is author-controlled, so this is a deliberate trade of crude prose-matching for predictability. If you want a hard escape hatch back, a `do-not-automerge` label check is the clean way to add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
